### PR TITLE
bump geopandas to 0.14.4 to fix error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-geopandas==0.14.3
+geopandas==0.14.4
 matplotlib
 numpy
 pandas


### PR DESCRIPTION
The site was erroring with `AttributeError: module 'fiona' has no attribute 'path'`

Fix by bumping geopandas to 0.14.4 as per https://stackoverflow.com/questions/78949093/how-to-resolve-attributeerror-module-fiona-has-no-attribute-path 